### PR TITLE
Add support for Python 3.7 dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Types and Classes are matched via `instanceof(value, pattern)`.
 | `{'type':'dog', age: _ }` | Any dict with `type: "dog"` and with an age | `{"type":"dog", "age": 3}` | `3` | `{"type":"cat", "age":2}` |
 | `{'type':'dog', age: int }` | Any dict with `type: "dog"` and with an `int` age | `{"type":"dog", "age": 3}` | `3` | `{"type":"dog", "age":2.3}` |
 | `re.compile('(\w+)-(\w+)-cat$')` | Any string that matches that regular expression expr | `"my-fuffy-cat"` | `"my"` and `"puffy"` | `"fuffy-dog"` | 
+| `Pet(name=_, age=7)` | Any Pet dataclass with `age == 7` | `Pet('rover', 7)` | `['rover']` | `Pet('rover', 8)` |
 
 ## Using strict=False
 
@@ -196,6 +197,22 @@ what_is('fuffy-my-dog')     # => 'dog fuffy'
 what_is('puffy-her-dog')    # => 'dog puffy'
 what_is('carla-your-cat')   # => 'cat carla'
 what_is('roger-my-hamster') # => 'something else'
+```
+
+## Using Dataclasses
+Pampy supports Python 3.7 dataclasses. You can pass the operator `_` as arguments and it will match those fields.
+
+```python
+@dataclass
+class Pet:
+    name: str
+    age: int
+
+pet = Pet('rover', 7)
+
+match(pet, Pet('rover', _), lambda age: age)                    # => 7
+match(pet, Pet(_, 7), lambda name: name)                        # => 'rover'
+match(pet, Pet(_, _), lambda name, age: (name, age))            # => ('rover', 7)
 ```
 
 ## Install

--- a/pampy/helpers.py
+++ b/pampy/helpers.py
@@ -45,3 +45,14 @@ def get_lambda_args_error_msg(action, var, err):
         return "Error passing arguments %s here:\n%s\n%s" % (var, code, err)
     except OSError:
         return "Error passing arguments %s:\n%s" % (var, err)
+
+
+def is_dataclass(value):
+    """
+    Dataclass support is only enabled in Python 3.7+, or in 3.6 with the `dataclasses` backport installed
+    """
+    try:
+        from dataclasses import is_dataclass
+        return is_dataclass(value)
+    except ImportError:
+        return False

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -63,6 +63,8 @@ def match_value(pattern, value) -> Tuple[bool, List]:
         return True, [value]
     elif pattern is HEAD or pattern is TAIL:
         raise MatchError("HEAD or TAIL should only be used inside an Iterable (list or tuple).")
+    elif is_dataclass(pattern):
+        return match_dict(pattern.__dict__, value.__dict__)
     return False, []
 
 

--- a/tests/test_elaborate.py
+++ b/tests/test_elaborate.py
@@ -2,8 +2,6 @@ import unittest
 
 from functools import reduce
 
-from dataclasses import dataclass
-
 from pampy import match, REST, TAIL, HEAD, _, match_value, match_iterable
 
 
@@ -100,6 +98,11 @@ class PampyElaborateTests(unittest.TestCase):
         self.assertEqual(f(18), "even 18")
 
     def test_dataclasses(self):
+        try:
+            from dataclasses import dataclass
+        except ImportError:
+            return
+
         @dataclass
         class Point:
             x: float

--- a/tests/test_elaborate.py
+++ b/tests/test_elaborate.py
@@ -2,6 +2,8 @@ import unittest
 
 from functools import reduce
 
+from dataclasses import dataclass
+
 from pampy import match, REST, TAIL, HEAD, _, match_value, match_iterable
 
 
@@ -96,6 +98,25 @@ class PampyElaborateTests(unittest.TestCase):
         self.assertEqual(f(3), "odd 3")
         self.assertEqual(f(18), "even 18")
         self.assertEqual(f(18), "even 18")
+
+    def test_dataclasses(self):
+        @dataclass
+        class Point:
+            x: float
+            y: float
+
+        def f(x):
+            return match(x,
+                Point(1, 2), '1',
+                Point(_, 2), str,
+                Point(1, _), str,
+                Point(_, _), lambda a, b: str(a + b)
+            )
+
+        self.assertEqual(f(Point(1, 2)), '1')
+        self.assertEqual(f(Point(2, 2)), '2')
+        self.assertEqual(f(Point(1, 3)), '3')
+        self.assertEqual(f(Point(2, 3)), '5')
 
 
     # def test_tree_traversal(self):


### PR DESCRIPTION
I added support for Python 3.7 dataclasses. We're prolific users of dataclasses where I work, and this would greatly help with simplifying the code base. Plus since dataclasses are straightforward in most cases (basically named dictionaries) then it's only an effectively 2 line change given the utilities Pampy already provides.

Before/after example with Pampy for implementing a simple AST transform:
```python
# Without pampy, recursively simplifying a + 0 = 0 + a = a
def simplify(expr):
    if isinstance(expr, BinaryExpression) and expr.operator = '+':
        if expr.a == 0:
            return simplify(expr.b)
        elif expr.b == 0:
            return simplify(expr.a)
    return expr
```

```python
# With pampy, recursively simplifying a + 0 = 0 + a = a
def simplify(expr):
    return match(expr,
        BinaryExpression('+', 0, _), simplify,
        BinaryExpression('+', _, 0), simplify,
        _,                           expr)
```