### PR TITLE
match on different types of dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ match(pet, Pet(_, 7), lambda name: name)                        # => 'rover'
 match(pet, Pet(_, _), lambda name, age: (name, age))            # => ('rover', 7)
 ```
 
+It is possible to match on different dataclasses withing the same invocation.
+
 ## Install
 
 Currently it works only in Python >= 3.6 [Because dict matching can work only in the latest Pythons](https://mail.python.org/pipermail/python-dev/2017-December/151283.html).
-
-I'm currently working on a backport with some minor syntax changes for Python2.
 
 To install it:
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,6 @@ match(pet, Pet(_, 7), lambda name: name)                        # => 'rover'
 match(pet, Pet(_, _), lambda name, age: (name, age))            # => ('rover', 7)
 ```
 
-It is possible to match on different dataclasses withing the same invocation.
-
 ## Install
 
 Currently it works only in Python >= 3.6 [Because dict matching can work only in the latest Pythons](https://mail.python.org/pipermail/python-dev/2017-December/151283.html).

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ match(pet, Pet(_, _), lambda name, age: (name, age))            # => ('rover', 7
 
 Currently it works only in Python >= 3.6 [Because dict matching can work only in the latest Pythons](https://mail.python.org/pipermail/python-dev/2017-December/151283.html).
 
+I'm currently working on a backport with some minor syntax changes for Python2.
+
 To install it:
 
 ```$ pip install pampy```

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -63,7 +63,7 @@ def match_value(pattern, value) -> Tuple[bool, List]:
         return True, [value]
     elif pattern is HEAD or pattern is TAIL:
         raise MatchError("HEAD or TAIL should only be used inside an Iterable (list or tuple).")
-    elif is_dataclass(pattern) and (pattern.__class__ == value.__class__):
+    elif is_dataclass(pattern) and pattern.__class__ == value.__class__:
         return match_dict(pattern.__dict__, value.__dict__)
     return False, []
 

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -63,7 +63,7 @@ def match_value(pattern, value) -> Tuple[bool, List]:
         return True, [value]
     elif pattern is HEAD or pattern is TAIL:
         raise MatchError("HEAD or TAIL should only be used inside an Iterable (list or tuple).")
-    elif is_dataclass(pattern):
+    elif is_dataclass(pattern) and (pattern.__class__ == value.__class__):
         return match_dict(pattern.__dict__, value.__dict__)
     return False, []
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -1,0 +1,32 @@
+import unittest
+
+from pampy import match, _
+from dataclasses import dataclass
+
+
+class PampyDataClassesTests(unittest.TestCase):
+
+
+    def test_match_dataclasses(self):
+        @dataclass
+        class Cat:
+            name: str
+            chassed_squirels: int
+
+        @dataclass
+        class Dog:
+            name: str
+            chassed_cats: int
+
+        def what_is(x):
+            return match(x,
+                         Dog(_, 0), 'good boy',
+                         Dog(_, _), 'doggy!',
+                         Cat(_,0), 'tommy?',
+                         Cat(_,_), 'a cat'
+                         )
+
+        self.assertEqual(what_is(Cat("cat", 0)), 'tommy?')
+        self.assertEqual(what_is(Cat("cat", 1)), 'a cat')
+        self.assertEqual(what_is(Dog("", 0)), 'good boy')
+        self.assertEqual(what_is(Dog("", 1)), 'doggy!')

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -1,16 +1,39 @@
 import unittest
-import pytest
-import sys
 
 from pampy import match, _
 
 
 class PampyDataClassesTests(unittest.TestCase):
 
-    @pytest.mark.skipif(sys.version_info < (3, 7),
-                        reason="requires python3.7 or higher")
-    def test_match_dataclasses(self):
-        from dataclasses import dataclass
+    def test_dataclasses(self):
+        try:
+            from dataclasses import dataclass
+        except ImportError:
+            return
+
+        @dataclass
+        class Point:
+            x: float
+            y: float
+
+        def f(x):
+            return match(x,
+                         Point(1, 2), '1',
+                         Point(_, 2), str,
+                         Point(1, _), str,
+                         Point(_, _), lambda a, b: str(a + b)
+                         )
+
+        self.assertEqual(f(Point(1, 2)), '1')
+        self.assertEqual(f(Point(2, 2)), '2')
+        self.assertEqual(f(Point(1, 3)), '3')
+        self.assertEqual(f(Point(2, 3)), '5')
+
+    def test_different_dataclasses(self):
+        try:
+            from dataclasses import dataclass
+        except ImportError:
+            return
         @dataclass
         class Cat:
             name: str
@@ -33,3 +56,4 @@ class PampyDataClassesTests(unittest.TestCase):
         self.assertEqual(what_is(Cat("cat", 1)), 'a cat')
         self.assertEqual(what_is(Dog("", 0)), 'good boy')
         self.assertEqual(what_is(Dog("", 1)), 'doggy!')
+

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -1,13 +1,16 @@
 import unittest
+import pytest
+import sys
 
 from pampy import match, _
-from dataclasses import dataclass
 
 
 class PampyDataClassesTests(unittest.TestCase):
 
-
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7 or higher")
     def test_match_dataclasses(self):
+        from dataclasses import dataclass
         @dataclass
         class Cat:
             name: str

--- a/tests/test_elaborate.py
+++ b/tests/test_elaborate.py
@@ -97,29 +97,6 @@ class PampyElaborateTests(unittest.TestCase):
         self.assertEqual(f(18), "even 18")
         self.assertEqual(f(18), "even 18")
 
-    def test_dataclasses(self):
-        try:
-            from dataclasses import dataclass
-        except ImportError:
-            return
-
-        @dataclass
-        class Point:
-            x: float
-            y: float
-
-        def f(x):
-            return match(x,
-                Point(1, 2), '1',
-                Point(_, 2), str,
-                Point(1, _), str,
-                Point(_, _), lambda a, b: str(a + b)
-            )
-
-        self.assertEqual(f(Point(1, 2)), '1')
-        self.assertEqual(f(Point(2, 2)), '2')
-        self.assertEqual(f(Point(1, 3)), '3')
-        self.assertEqual(f(Point(2, 3)), '5')
 
 
     # def test_tree_traversal(self):


### PR DESCRIPTION
It is I think fairly self explanatory. The condition `(patter.__class__ == value.__class__)` should be a no op for current use. But if we try to match on multiple dataclasses it will allow for correct resolution. 