### PR TITLE
Switch to using default for fallback values instead of strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,17 +168,17 @@ Types and Classes are matched via `instanceof(value, pattern)`.
 | `re.compile('(\w+)-(\w+)-cat$')` | Any string that matches that regular expression expr | `"my-fuffy-cat"` | `"my"` and `"puffy"` | `"fuffy-dog"` | 
 | `Pet(name=_, age=7)` | Any Pet dataclass with `age == 7` | `Pet('rover', 7)` | `['rover']` | `Pet('rover', 8)` |
 
-## Using strict=False
+## Using default
 
 By default `match()` is strict. If no pattern matches, it raises a `MatchError`.
 
-You can prevent it using `strict=False`. In this case `match` just returns `False` if nothing matches.
+You can instead provide a fallback value using `default` to be used when nothing matches.
 
 ```
 >>> match([1, 2], [1, 2, 3], "whatever")
 MatchError: '_' not provided. This case is not handled: [1, 2]
 
->>> match([1, 2], [1, 2, 3], "whatever", strict=False)
+>>> match([1, 2], [1, 2, 3], "whatever", default=False)
 False
 ```
 

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -5,7 +5,6 @@ from typing import Pattern as RegexPattern
 
 from pampy.helpers import *
 
-ValueType = (int, float, str, bool)
 _ = ANY = UnderscoreType()
 HEAD = HeadType()
 REST = TAIL = TailType()
@@ -29,7 +28,7 @@ def run(action, var):
 def match_value(pattern, value) -> Tuple[bool, List]:
     if value is PaddedValue:
         return False, []
-    elif isinstance(pattern, ValueType):
+    elif isinstance(pattern, (int, float, str, bool)):
         eq = pattern == value
         type_eq = type(pattern) == type(value)
         return eq and type_eq, []
@@ -140,9 +139,43 @@ def match_iterable(patterns, values) -> Tuple[bool, List]:
     return True, total_extracted
 
 
-def match(var, *args, strict=True):
+class _NoDefault:
+    pass
+
+
+NoDefault = _NoDefault()
+
+
+def match(var, *args, default=NoDefault, strict=True):
+    """
+    Match `var` against a number of potential patterns.
+
+    Example usage:
+    ```
+    match(x,
+        3,              "this matches the number 3",
+        int,            "matches any integer",
+        (str, int),     lambda a, b: "a tuple (a, b) you can use in a function",
+        [1, 2, _],      "any list of 3 elements that begins with [1, 2]",
+        {'x': _},       "any dict with a key 'x' and any value associated",
+        _,              "anything else"
+    )
+    ```
+
+    :param var: The variable to test patterns against.
+    :param args: Alternating patterns and actions. There must be an action for every pattern specified.
+                 Patterns can take many forms, see README.md for examples.
+                 Actions can be either a literal value or a callable which will be called with the arguments that were
+                    matched in corresponding pattern.
+    :param default: If `default` is specified then it will be returned if none of the patterns match.
+                    If `default` is unspecified then a `MatchError` will be thrown instead.
+    :return: The result of the action which corresponds to the first matching pattern.
+    """
     if len(args) % 2 != 0:
         raise MatchError("Every guard must have an action.")
+
+    if default is NoDefault and strict is False:
+        default = False
 
     pairs = list(pairwise(args))
     patterns = [patt for (patt, action) in pairs]
@@ -154,11 +187,11 @@ def match(var, *args, strict=True):
             lambda_args = args if len(args) > 0 else BoxedArgs(var)
             return run(action, lambda_args)
 
-    if strict:
+    if default is NoDefault:
         if _ not in patterns:
             raise MatchError("'_' not provided. This case is not handled:\n%s" % str(var))
     else:
-        return False
+        return default
 
 
 class MatchError(Exception):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -83,6 +83,10 @@ class PampyBasicTests(unittest.TestCase):
     def test_match_not_strict_returns_false(self):
         self.assertFalse(match(3, 2, True, strict=False))
 
+    def test_match_default(self):
+        self.assertFalse(match(3, 2, True, default=False))
+        self.assertEqual(match(3, 2, True, default=6), 6)
+
     def test_match_arguments_passing(self):
         self.assertEqual(match([1, 2, 3], [1, _, 3], lambda x: x), 2)
         self.assertEqual(match([1, 2, 3], [1, 2, 3], lambda x: x), [1, 2, 3])


### PR DESCRIPTION
Change `strict` to `default` in calls to `match` so that it is more aligned with other Python functions.

For instance, functions on dictionaries like `get` have the signature:
`def get(self, k, default)` where the default will be returned instead of throwing an error.

The old behaviour on `strict` can still be emulated by passing `default=False`. Also kept `strict` working for backwards compatibility.

Finally, this documents the `match` public function.