### PR TITLE
Add any behaiour to match function with callables

### DIFF
--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -37,19 +37,17 @@ def match_value(pattern, value) -> Tuple[bool, List]:
     elif isinstance(pattern, type):
         if isinstance(value, pattern):
             return True, [value]
-        else:
-            return False, []
     elif isinstance(pattern, (list, tuple)):
         return match_iterable(pattern, value)
     elif isinstance(pattern, dict):
         return match_dict(pattern, value)
     elif callable(pattern):
         return_value = pattern(value)
-        if return_value is True:
-            return True, [value]
-        elif return_value is False:
-            pass
-        elif match_value((True, list), return_value)[0] is True:
+
+        if isinstance(return_value, bool):
+            return return_value, [value]
+        elif isinstance(return_value, tuple) and len(return_value) == 2 \
+                and isinstance(return_value[0], bool) and isinstance(return_value[1], list):
             return return_value
         else:
             raise MatchError("Warning! pattern function %s is not returning a boolean "

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -49,8 +49,11 @@ def match_value(pattern, value) -> Tuple[bool, List]:
             return True, [value]
         elif return_value is False:
             pass
+        elif match_value((True, list), return_value)[0] is True:
+            return return_value
         else:
-            raise MatchError("Warning! pattern function %s is not returning a boolean, but instead %s" %
+            raise MatchError("Warning! pattern function %s is not returning a boolean "
+                             "nor a tuple of (boolean, list), but instead %s" %
                              (pattern, return_value))
     elif isinstance(pattern, RegexPattern):
         rematch = pattern.search(value)

--- a/tests/test_elaborate.py
+++ b/tests/test_elaborate.py
@@ -116,3 +116,44 @@ class PampyElaborateTests(unittest.TestCase):
             return sum(cutenesses) / len(cutenesses)
 
         self.assertEqual(avg_cuteness_pampy(), (4 + 3 + 4.6 + 7) / 4)
+
+    def test_advanced_lambda(self):
+        def either(pattern1, pattern2):
+            """Matches values satisfying pattern1 OR pattern2"""
+            def repack(*args):
+                return True, list(args)
+
+            def f(x):
+                return match(x,
+                     pattern1, repack,
+                     pattern2, repack,
+                     _,        (False, [])
+                )
+
+            return f
+
+        self.assertEqual(match('str', either(int, str), 'success'), 'success')
+
+    def test_dataclasses(self):
+        try:
+            from dataclasses import dataclass
+        except ImportError:
+            return
+
+        @dataclass
+        class Point:
+            x: float
+            y: float
+
+        def f(x):
+            return match(x,
+                Point(1, 2), '1',
+                Point(_, 2), str,
+                Point(1, _), str,
+                Point(_, _), lambda a, b: str(a + b)
+            )
+
+        self.assertEqual(f(Point(1, 2)), '1')
+        self.assertEqual(f(Point(2, 2)), '2')
+        self.assertEqual(f(Point(1, 3)), '3')
+        self.assertEqual(f(Point(2, 3)), '5')

--- a/tests/test_elaborate.py
+++ b/tests/test_elaborate.py
@@ -165,27 +165,3 @@ class PampyElaborateTests(unittest.TestCase):
         self.assertEqual(test(datetime(2018, 1, 2)), '1/2 in 2018')
         self.assertEqual(test(datetime(2017, 1, 2, 3, 4, 5)), 'any datetime')
         self.assertEqual(test(11), 'not a datetime')
-
-    def test_dataclasses(self):
-        try:
-            from dataclasses import dataclass
-        except ImportError:
-            return
-
-        @dataclass
-        class Point:
-            x: float
-            y: float
-
-        def test(x):
-            return match(x,
-                Point(1, 2), '1',
-                Point(_, 2), str,
-                Point(1, _), str,
-                Point(_, _), lambda a, b: str(a + b)
-            )
-
-        self.assertEqual(test(Point(1, 2)), '1')
-        self.assertEqual(test(Point(2, 2)), '2')
-        self.assertEqual(test(Point(1, 3)), '3')
-        self.assertEqual(test(Point(2, 3)), '5')


### PR DESCRIPTION
This is a relatively simple way to allow people to add custom patterns on any type, or even combinations of patterns.

Previously pampy allowed a pattern to be a lamba which returns a boolean. This extends that to allow a lambda which returns both a boolean (for whether there was a match) and a list (for the matched values).

For instance with the datetime type, it would be difficult to create a pattern for this because the datetime constructor does type checking:
```python
>>> datetime(2018, _, _)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: an integer is required (got type UnderscoreType)
```

In the tests I give an example of a datetime pattern `datetime_p` which works as expected:
```python
match(var, datetime_p(2018, _, _), lambda month, day: f'{month}/{day} in 2018')
```

Similarly you can create more advanced patterns that are combinations of other smaller patterns (like matching one pattern OR another pattern) and could satisfy the multiple guards suggestion from #10 

PS. The existing lambda behavior was undocumented so I didn't write any docs for this either. Would be happy to add that though.