### PR TITLE
Add type annotations support for matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ match(pet, Pet(_, _), lambda name, age: (name, age))            # => ('rover', 7
 ```
 
 ## Using typing
-Pampy supports typing annotations
+Pampy supports typing annotations.
 
 ```python
 
@@ -177,6 +177,7 @@ match(None, Optional[str], lambda x: x)                         # => None
 match(Pet, Type[Pet], lambda x: x)                              # => Pet
 match(Cat, Type[Pet], lambda x: x)                              # => Cat
 match(Dog, Any, lambda x: x)                                    # => Dog
+match(Dog, Type[Any], lambda x: x)                              # => Dog
 match(15, timestamp, lambda x: x)                               # => 15
 match(10.0, timestamp, lambda x: x)                             # => 10.0
 match([1, 2, 3], List[int], lambda x: x)                        # => [1, 2, 3]
@@ -190,8 +191,48 @@ For iterable generics actual type of value is guessed based on the first element
 match([1, 2, 3], List[int], lambda x: x)                        # => [1, 2, 3]
 match([1, "b", "a"], List[int], lambda x: x)                    # => [1, "b", "a"]
 match(["a", "b", "c"], List[int], lambda x: x)                  # raises MatchError
+match(["a", "b", "c"], List[Union[str, int]], lambda x: x)      # ["a", "b", "c"]
+
+match({"a": 1, "b": 2}, Dict[str, int], lambda x: x)            # {"a": 1, "b": 2}
+match({"a": 1, "b": "dog"}, Dict[str, int], lambda x: x)        # {"a": 1, "b": "dog"}
+match({"a": 1, 1: 2}, Dict[str, int], lambda x: x)              # {"a": 1, 1: 2}
+match({2: 1, 1: 2}, Dict[str, int], lambda x: x)                # raises MatchError
+match({2: 1, 1: 2}, Dict[Union[str, int], int], lambda x: x)    # {2: 1, 1: 2}
 ```
-For Callable any arg without annotation treated as Any. TypeVar is not supported.
+Iterable generics also match with any of their subtypes.
+```python
+match([1, 2, 3], Iterable[int], lambda x: x)                     # => [1, 2, 3]
+match({1, 2, 3}, Iterable[int], lambda x: x)                     # => {1, 2, 3}
+match(range(10), Iterable[int], lambda x: x)                     # => range(10)
+
+match([1, 2, 3], List[int], lambda x: x)                         # => [1, 2, 3]
+match({1, 2, 3}, List[int], lambda x: x)                         # => raises MatchError
+match(range(10), List[int], lambda x: x)                         # => raises MatchError
+
+match([1, 2, 3], Set[int], lambda x: x)                          # => raises MatchError
+match({1, 2, 3}, Set[int], lambda x: x)                          # => {1, 2, 3}
+match(range(10), Set[int], lambda x: x)                          # => raises MatchError
+```
+For Callable any arg without annotation treated as Any. 
+```python
+def annotated(a: int, b: int) -> float:
+    pass
+    
+def not_annotated(a, b):
+    pass
+    
+def partially_annotated(a, b: float):
+    pass
+
+match(annotated, Callable[[int, int], float], lambda x: x)     # => annotated
+match(not_annotated, Callable[[int, int], float], lambda x: x) # => raises MatchError
+match(not_annotated, Callable[[Any, Any], Any], lambda x: x)   # => not_annotated
+match(annotated, Callable[[Any, Any], Any], lambda x: x)       # => raises MatchError
+match(partially_annotated, 
+    Callable[[Any, float], Any], lambda x: x
+)                                                              # => partially_annotated
+```
+TypeVar is not supported.
 
 ## All the things you can match
 
@@ -226,6 +267,10 @@ Types and Classes are matched via `instanceof(value, pattern)`.
 | `Union[int, float, None]` | Any integer or float number or None | `2.35` | `2.35` | any other value |
 | `Optional[int]` | The same as `Union[int, None]` | `2` | `2` | any other value |
 | `Type[MyClass]` | Any subclass of MyClass. **And any class that extends MyClass.** | `MyClass` | that class | any other object |
+| `Callable[[int], float]` | Any callable with exactly that signature | `def a(q:int) -> float: ...` | that function | `def a(q) -> float: ...` |
+| `Tuple[MyClass, int, float]` | The same as `(MyClass, int, float)` | | | |
+| `Mapping[str, int]` Any subtype of `Mapping` acceptable too | any mapping or subtype of mapping with string keys and integer values | `{'a': 2, 'b': 3}` | that dict | `{'a': 'b', 'b': 'c'}` |
+| `Iterable[int]` Any subtype of `Iterable` acceptable too | any iterable or subtype of iterable with integer values | `range(10)` and `[1, 2, 3]` | that iterable | `['a', 'b', 'v']` |
 
 
 ## Using default

--- a/pampy/helpers.py
+++ b/pampy/helpers.py
@@ -1,4 +1,9 @@
 import inspect
+from typing import (
+    GenericMeta,
+    Union,
+    Any,
+)
 
 
 class UnderscoreType:
@@ -62,3 +67,19 @@ def is_dataclass(value):
         return is_dataclass(value)
     except ImportError:
         return False
+
+
+def is_newtype(pattern):
+    return inspect.isfunction(pattern) and hasattr(pattern, '__supertype__')
+
+
+def is_generic(pattern):
+    return isinstance(pattern, GenericMeta)
+
+
+def is_union(pattern):
+    return isinstance(pattern, Union.__class__)
+
+
+def is_typing_stuff(pattern):
+    return pattern == Any or is_generic(pattern) or is_union(pattern) or is_newtype(pattern)

--- a/pampy/helpers.py
+++ b/pampy/helpers.py
@@ -1,11 +1,15 @@
 import inspect
 from typing import (
-    GenericMeta,
     Union,
     Any,
     Iterable,
     TypeVar,
 )
+
+try:
+    from typing import GenericMeta
+except ImportError:
+    from typing import _GenericAlias as GenericMeta
 
 T = TypeVar("T")
 
@@ -73,6 +77,10 @@ def is_dataclass(value):
         return False
 
 
+def get_extra(pattern):
+    return getattr(pattern, "__extra__", None) or getattr(pattern, "__origin__", None)
+
+
 def peek(iter_: Iterable[T]) -> T:
     return next(iter(iter_))
 
@@ -86,7 +94,7 @@ def is_generic(pattern):
 
 
 def is_union(pattern):
-    return isinstance(pattern, Union.__class__)
+    return isinstance(pattern, Union.__class__) or getattr(pattern, "__origin__", None) == Union
 
 
 def is_typing_stuff(pattern):

--- a/pampy/helpers.py
+++ b/pampy/helpers.py
@@ -3,7 +3,11 @@ from typing import (
     GenericMeta,
     Union,
     Any,
+    Iterable,
+    TypeVar,
 )
+
+T = TypeVar("T")
 
 
 class UnderscoreType:
@@ -67,6 +71,10 @@ def is_dataclass(value):
         return is_dataclass(value)
     except ImportError:
         return False
+
+
+def peek(iter_: Iterable[T]) -> T:
+    return next(iter(iter_))
 
 
 def is_newtype(pattern):

--- a/pampy/helpers.py
+++ b/pampy/helpers.py
@@ -83,3 +83,10 @@ def is_union(pattern):
 
 def is_typing_stuff(pattern):
     return pattern == Any or is_generic(pattern) or is_union(pattern) or is_newtype(pattern)
+
+
+def get_real_type(subtype):
+    if is_newtype(subtype):
+        return get_real_type(subtype.__supertype__)
+    else:
+        return subtype

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -197,6 +197,8 @@ def match_generic(pattern: Generic[T], value) -> Tuple[bool, List]:
             return False, []
 
         type_ = pattern.__args__[0]
+        if type_ == Any:
+            return True, [real_value or value]
         if is_newtype(type_):   # NewType case
             type_ = get_real_type(type_)
 

--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -2,13 +2,20 @@ from collections import Iterable
 from itertools import zip_longest
 from enum import Enum
 from typing import (
+    Generic,
+    TypeVar,
     Tuple,
     List,
     Pattern as RegexPattern,
+    Callable,
+    Type,
+    NewType
 )
+import inspect
 
 from pampy.helpers import *
 
+T = TypeVar('T')
 _ = ANY = UnderscoreType()
 HEAD = HeadType()
 REST = TAIL = TailType()
@@ -162,8 +169,20 @@ def match_typing_stuff(pattern, value) -> Tuple[bool, List]:
         return False, []
 
 
-def match_generic(pattern, value) -> Tuple[bool, List]:
-    pass
+def match_generic(pattern: Generic[T], value) -> Tuple[bool, List]:
+    if pattern.__extra__ == type:       # Type[int] for example
+        if not inspect.isclass(value):
+            return False, []
+        type_ = pattern.__args__[0]
+        if inspect.isfunction(type_):   # NewType case
+            pass
+
+    elif isinstance(pattern, Callable.__class__):
+        if callable(value):
+            spec = inspect.getfullargspec(value)
+
+        else:
+            return False, []
 
 
 def match(var, *args, default=NoDefault, strict=True):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -152,4 +152,3 @@ class PampyBasicTests(unittest.TestCase):
         self.assertEqual(match(Color.RED, Color.BLUE, "blue", Color.RED, "red", _, "else"), "red")
         self.assertEqual(match(Color.RED, Color.BLUE, "blue", Color.GREEN, "green", _, "else"), "else")
         self.assertEqual(match(1, Color.BLUE, "blue", Color.GREEN, "green", _, "else"), "else")
-        

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -5,6 +5,8 @@ from typing import (
     Union,
     Tuple,
     NewType,
+    Optional,
+    Type,
 )
 
 from pampy import (
@@ -23,6 +25,9 @@ class PampyTypingTests(unittest.TestCase):
         self.assertEqual(match_value(Union[int, str], 3), (True, [3]))
         self.assertEqual(match_value(Union[int, str], 'ok'), (True, ['ok']))
         self.assertEqual(match_value(Union[int, str, float], 5.25), (True, [5.25]))
+        self.assertEqual(match_value(Optional[int], None), (True, [None]))
+        self.assertEqual(match_value(Optional[int], 1), (True, [1]))
+        self.assertEqual(match_value(Optional[int], 1.0), (False, []))
 
     def test_match_newtype(self):
         lol = NewType("lol", int)
@@ -33,6 +38,17 @@ class PampyTypingTests(unittest.TestCase):
 
         self.assertEqual(match_value(lol, 3), (True, [3]))
         self.assertEqual(match_value(kek, 3), (True, [3]))
-        self.assertEqual(match_value(double_kek, (13, 37)), (True, [13, 37]))
-        self.assertEqual(match_value(composite_kek, "Barsik"), (True, ["barsik"]))
-        self.assertEqual(match_value(composite_kek, (13, 37)), (True, [13, 37]))
+        # self.assertEqual(match_value(double_kek, (13, 37)), (True, [13, 37]))
+        # self.assertEqual(match_value(composite_kek, "Barsik"), (True, ["Barsik"]))
+        # self.assertEqual(match_value(composite_kek, (13, 37)), (True, [13, 37]))
+
+    def test_match_type(self):
+        lol = NewType("lol", int)
+        kek = NewType("kek", lol)
+
+        self.assertEqual(match_value(Type[int], int), (True, [int]))
+        self.assertEqual(match_value(Type[int], 1), (False, []))
+
+        self.assertEqual(match_value(Type[lol], lol), (True, [lol]))
+        self.assertEqual(match_value(Type[int], lol), (True, [lol]))
+        self.assertEqual(match_value(Type[lol], int), (False, []))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,38 @@
+import unittest
+from typing import (
+    List,
+    Any,
+    Union,
+    Tuple,
+    NewType,
+)
+
+from pampy import (
+    match,
+    match_value,
+)
+
+
+class PampyTypingTests(unittest.TestCase):
+
+    def test_match_any(self):
+        self.assertEqual(match_value(Any, 3), (True, [3]))
+        self.assertEqual(match_value(Any, 'ok'), (True, ['ok']))
+
+    def test_match_union(self):
+        self.assertEqual(match_value(Union[int, str], 3), (True, [3]))
+        self.assertEqual(match_value(Union[int, str], 'ok'), (True, ['ok']))
+        self.assertEqual(match_value(Union[int, str, float], 5.25), (True, [5.25]))
+
+    def test_match_newtype(self):
+        lol = NewType("lol", int)
+        kek = NewType("kek", lol)
+        cat = NewType("cat", str)
+        double_kek = NewType('double_kek', Tuple[kek, kek])
+        composite_kek = NewType("CKek", Union[cat, double_kek])
+
+        self.assertEqual(match_value(lol, 3), (True, [3]))
+        self.assertEqual(match_value(kek, 3), (True, [3]))
+        self.assertEqual(match_value(double_kek, (13, 37)), (True, [13, 37]))
+        self.assertEqual(match_value(composite_kek, "Barsik"), (True, ["barsik"]))
+        self.assertEqual(match_value(composite_kek, (13, 37)), (True, [13, 37]))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,6 @@
 import unittest
 from typing import (
+    Callable,
     List,
     Any,
     Union,
@@ -46,9 +47,45 @@ class PampyTypingTests(unittest.TestCase):
         lol = NewType("lol", int)
         kek = NewType("kek", lol)
 
+        class A:
+            pass
+
+        class B(A):
+            pass
+
+        class C(A):
+            pass
+
+        E = NewType("E", B)
+
         self.assertEqual(match_value(Type[int], int), (True, [int]))
         self.assertEqual(match_value(Type[int], 1), (False, []))
+        self.assertEqual(match_value(Type[E], "cat"), (False, []))
+        self.assertEqual(match_value(Type[A], "cat"), (False, []))
 
-        self.assertEqual(match_value(Type[lol], lol), (True, [lol]))
-        self.assertEqual(match_value(Type[int], lol), (True, [lol]))
-        self.assertEqual(match_value(Type[lol], int), (False, []))
+        self.assertEqual(match_value(Type[lol], int), (True, [int]))
+        self.assertEqual(match_value(Type[kek], int), (True, [int]))
+        self.assertEqual(match_value(Type[kek], str), (False, []))
+
+        self.assertEqual(match_value(Type[A], A), (True, [A]))
+        self.assertEqual(match_value(Type[A], B), (True, [B]))
+        self.assertEqual(match_value(Type[B], C), (False, []))
+        self.assertEqual(match_value(Type[E], B), (True, [B]))
+        self.assertEqual(match_value(Type[E], C), (False, []))
+        self.assertEqual(match_value(Type[C], A), (False, []))
+
+    def test_match_callable(self):
+
+        def a_1(a: int) -> float:
+            pass
+
+        self.assertEqual(match_value(Callable[[int], float], a_1), (True, [a_1]))
+
+    def test_match_tuple(self):
+        pass
+
+    def test_match_named_tuple(self):
+        pass
+
+    def test_match_collection(self):
+        pass

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,6 +2,9 @@ import unittest
 from typing import (
     Callable,
     List,
+    Set,
+    FrozenSet,
+    Dict,
     Any,
     Union,
     Tuple,
@@ -14,6 +17,42 @@ from pampy import (
     match,
     match_value,
 )
+
+
+class A:
+    pass
+
+
+class B(A):
+    pass
+
+
+class C(A):
+    pass
+
+
+E = NewType("E", B)
+lol = NewType("lol", int)
+kek = NewType("kek", lol)
+cat = NewType("cat", str)
+double_kek = NewType('double_kek', Tuple[kek, kek])
+composite_kek = NewType("CKek", Union[cat, double_kek])
+
+
+def annotated(a: int) -> float:
+    pass
+
+
+def big_annotated(a: Tuple[int, float], b: str, c: E) -> double_kek:
+    pass
+
+
+def wrong_annotated(b: str) -> str:
+    pass
+
+
+def not_annotated(q):
+    pass
 
 
 class PampyTypingTests(unittest.TestCase):
@@ -31,33 +70,13 @@ class PampyTypingTests(unittest.TestCase):
         self.assertEqual(match_value(Optional[int], 1.0), (False, []))
 
     def test_match_newtype(self):
-        lol = NewType("lol", int)
-        kek = NewType("kek", lol)
-        cat = NewType("cat", str)
-        double_kek = NewType('double_kek', Tuple[kek, kek])
-        composite_kek = NewType("CKek", Union[cat, double_kek])
-
         self.assertEqual(match_value(lol, 3), (True, [3]))
         self.assertEqual(match_value(kek, 3), (True, [3]))
-        # self.assertEqual(match_value(double_kek, (13, 37)), (True, [13, 37]))
-        # self.assertEqual(match_value(composite_kek, "Barsik"), (True, ["Barsik"]))
-        # self.assertEqual(match_value(composite_kek, (13, 37)), (True, [13, 37]))
+        self.assertEqual(match_value(double_kek, (13, 37)), (True, [13, 37]))
+        self.assertEqual(match_value(composite_kek, "Barsik"), (True, ["Barsik"]))
+        self.assertEqual(match_value(composite_kek, (13, 37)), (True, [13, 37]))
 
     def test_match_type(self):
-        lol = NewType("lol", int)
-        kek = NewType("kek", lol)
-
-        class A:
-            pass
-
-        class B(A):
-            pass
-
-        class C(A):
-            pass
-
-        E = NewType("E", B)
-
         self.assertEqual(match_value(Type[int], int), (True, [int]))
         self.assertEqual(match_value(Type[int], 1), (False, []))
         self.assertEqual(match_value(Type[E], "cat"), (False, []))
@@ -71,21 +90,107 @@ class PampyTypingTests(unittest.TestCase):
         self.assertEqual(match_value(Type[A], B), (True, [B]))
         self.assertEqual(match_value(Type[B], C), (False, []))
         self.assertEqual(match_value(Type[E], B), (True, [B]))
+
+        self.assertEqual(match_value(Type[A], E), (True, [E]))
+
         self.assertEqual(match_value(Type[E], C), (False, []))
         self.assertEqual(match_value(Type[C], A), (False, []))
 
     def test_match_callable(self):
-
-        def a_1(a: int) -> float:
-            pass
-
-        self.assertEqual(match_value(Callable[[int], float], a_1), (True, [a_1]))
+        self.assertEqual(match_value(Callable[[int], float], annotated), (True, [annotated]))
+        self.assertEqual(
+            match_value(Callable[[Tuple[int, float], str, E], double_kek], big_annotated), (True, [big_annotated])
+        )
+        self.assertEqual(match_value(Callable[[int], float], not_annotated), (False, []))
+        self.assertEqual(match_value(Callable[[Any], Any], not_annotated), (True, [not_annotated]))
+        self.assertEqual(match_value(Callable[[int], float], wrong_annotated), (False, []))
 
     def test_match_tuple(self):
-        pass
+        self.assertEqual(
+            match_value(Tuple[int, str], (1, "a")),
+            (True, [1, "a"])
+        )
+        self.assertEqual(
+            match_value(Tuple[int, str], (1, 1)),
+            (False, [])
+        )
+        self.assertEqual(
+            match_value(
+                Tuple[
+                    Union[int, float],
+                    Callable[[int], float],
+                    Tuple[str, Type[E]]
+                ],
+                (1.0, annotated, ("ololo", B))
+            ),
+            (True, [1.0, annotated, "ololo", B])
+        )
+        self.assertEqual(
+            match_value(
+                Tuple[
+                    Union[int, float],
+                    Callable[[int], float],
+                    Tuple[str, Type[E]]
+                ],
+                (1.0, False, ("ololo", B))
+            ),
+            (False, [])
+        )
+        self.assertEqual(
+            match_value(
+                Tuple[
+                    Union[int, float],
+                    Callable[[int], float],
+                    Tuple[str, Type[E]]
+                ],
+                ("kek", annotated, ("ololo", B))
+            ),
+            (False, [])
+        )
+        self.assertEqual(
+            match_value(
+                Tuple[
+                    Union[int, float],
+                    Callable[[int], float],
+                    Tuple[str, Type[E]]
+                ],
+                (1, annotated, ("ololo", B, 1488))
+            ),
+            (False, [])
+        )
+        self.assertEqual(
+            match_value(
+                Tuple[
+                    Union[int, float],
+                    Callable[[int], float],
+                    Tuple[str, Type[A]]
+                ],
+                (1, annotated, ("ololo", E))
+            ),
+            (True, [1, annotated, "ololo", E])
+        )
 
-    def test_match_named_tuple(self):
-        pass
+    def test_match_mapping(self):
+        self.assertEqual(match_value(Dict[str, int], {"a": 1, "b": 2}), (True, [{"a": 1, "b": 2}]))
+        self.assertEqual(match_value(Dict[str, lol], {"a": 1, "b": 2}), (True, [{"a": 1, "b": 2}]))
+        self.assertEqual(match_value(Dict[str, int], {"a": 1.0, "b": 2.0}), (False, []))
+        self.assertEqual(match_value(Dict[str, int], {1: 1, 2: 2}), (False, []))
+        self.assertEqual(match_value(Dict[Union[str, int], int], {1: 1, 2: 2}), (True, [{1: 1, 2: 2}]))
+        self.assertEqual(match_value(Dict[Union[str, lol], int], {1: 1, 2: 2}), (True, [{1: 1, 2: 2}]))
+        self.assertEqual(
+            match_value(Dict[str, Callable[[int], float]], {"a": annotated, "b": annotated}),
+            (True, [{"a": annotated, "b": annotated}])
+        )
 
-    def test_match_collection(self):
-        pass
+    def test_match_iterable(self):
+        self.assertEqual(match_value(List[int], [1, 2, 3]), (True, [[1, 2, 3]]))
+        self.assertEqual(match_value(List[lol], [1, 2, 3]), (True, [[1, 2, 3]]))
+        self.assertEqual(match_value(List[str], [1, 2, 3]), (False, []))
+        a_vals = [B(), C(), B()]
+        self.assertEqual(match_value(List[A], a_vals), (True, [a_vals]))
+        self.assertEqual(match_value(List[str], ["lol", "kek"]), (True, [["lol", "kek"]]))
+        self.assertEqual(match_value(List[Union[str, int]], ["lol", "kek"]), (True, [["lol", "kek"]]))
+        self.assertEqual(match_value(List[Union[str, int]], [1, 2, 3]), (True, [[1, 2, 3]]))
+        self.assertEqual(match_value(List[int], {1, 2, 3}), (False, []))
+        self.assertEqual(match_value(Set[int], {1, 2, 3}), (True, [{1, 2, 3}]))
+        self.assertEqual(match_value(FrozenSet[int], frozenset([1, 2, 3])), (True, [frozenset([1, 2, 3])]))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -4,6 +4,8 @@ from typing import (
     List,
     Set,
     FrozenSet,
+    Mapping,
+    Iterable,
     Dict,
     Any,
     Union,
@@ -30,6 +32,9 @@ class B(A):
 class C(A):
     pass
 
+
+class Z:
+    pass
 
 E = NewType("E", B)
 lol = NewType("lol", int)
@@ -95,6 +100,10 @@ class PampyTypingTests(unittest.TestCase):
 
         self.assertEqual(match_value(Type[E], C), (False, []))
         self.assertEqual(match_value(Type[C], A), (False, []))
+
+        self.assertEqual(match_value(Type[Any], A), (True, [A]))
+        self.assertEqual(match_value(Type[Any], Z), (True, [Z]))
+        self.assertEqual(match_value(Type[Any], int), (True, [int]))
 
     def test_match_callable(self):
         self.assertEqual(match_value(Callable[[int], float], annotated), (True, [annotated]))
@@ -172,9 +181,11 @@ class PampyTypingTests(unittest.TestCase):
 
     def test_match_mapping(self):
         self.assertEqual(match_value(Dict[str, int], {"a": 1, "b": 2}), (True, [{"a": 1, "b": 2}]))
+        self.assertEqual(match_value(Mapping[str, lol], {"a": 1, "b": 2}), (True, [{"a": 1, "b": 2}]))
         self.assertEqual(match_value(Dict[str, lol], {"a": 1, "b": 2}), (True, [{"a": 1, "b": 2}]))
         self.assertEqual(match_value(Dict[str, int], {"a": 1.0, "b": 2.0}), (False, []))
         self.assertEqual(match_value(Dict[str, int], {1: 1, 2: 2}), (False, []))
+        self.assertEqual(match_value(Mapping[str, int], {1: 1, 2: 2}), (False, []))
         self.assertEqual(match_value(Dict[Union[str, int], int], {1: 1, 2: 2}), (True, [{1: 1, 2: 2}]))
         self.assertEqual(match_value(Dict[Union[str, lol], int], {1: 1, 2: 2}), (True, [{1: 1, 2: 2}]))
         self.assertEqual(
@@ -184,8 +195,12 @@ class PampyTypingTests(unittest.TestCase):
 
     def test_match_iterable(self):
         self.assertEqual(match_value(List[int], [1, 2, 3]), (True, [[1, 2, 3]]))
+        self.assertEqual(match_value(List[int], range(10)), (False, []))
+        self.assertEqual(match_value(Iterable[int], [1, 2, 3]), (True, [[1, 2, 3]]))
+        self.assertEqual(match_value(Iterable[int], range(10)), (True, [range(10)]))
         self.assertEqual(match_value(List[lol], [1, 2, 3]), (True, [[1, 2, 3]]))
         self.assertEqual(match_value(List[str], [1, 2, 3]), (False, []))
+        self.assertEqual(match_value(Iterable[str], [1, 2, 3]), (False, []))
         a_vals = [B(), C(), B()]
         self.assertEqual(match_value(List[A], a_vals), (True, [a_vals]))
         self.assertEqual(match_value(List[str], ["lol", "kek"]), (True, [["lol", "kek"]]))


### PR DESCRIPTION
Greetings!

I implemented pattern matching support for type annotations from the typing module. You may see how it looks like in the new [elaborate test ](https://github.com/Ecialo/pampy/blob/typing/tests/test_elaborate.py#L194)