### PR TITLE
fix deprecation warning on python3.7

### DIFF
--- a/pampy/pampy.py
+++ b/pampy/pampy.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from itertools import zip_longest
 from enum import Enum
 from typing import Tuple, List


### PR DESCRIPTION
```/usr/local/lib/python3.7/site-packages/pampy/pampy.py:1
  /usr/local/lib/python3.7/site-packages/pampy/pampy.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable
```